### PR TITLE
Mark cordova as devDependencies and peerDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,22 +22,21 @@
   ],
   "main": "Gruntfile.js",
   "engines": {
-    "node": ">= 0.10.24"
+    "node": "^0.10.24"
   },
   "scripts": {
     "test": "grunt test"
   },
-  "dependencies": {
-    "cordova": ">= 3.4"
-  },
   "devDependencies": {
+    "cordova": "^3.5.0-0.2.7",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
-    "grunt-contrib-clean": "^0.5.0",
+    "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-nodeunit": "^0.4.0"
+    "grunt-contrib-nodeunit": "^0.4.1"
   },
   "peerDependencies": {
+    "cordova": "^3.5.0-0.2.7",
     "grunt": "^0.4.5"
   },
   "keywords": [


### PR DESCRIPTION
"cordova": ">= 3.4" not works with latest npm because of its x.y.z-a.b.c version style.

On the other hand, cordova prefer install with "npm -g install cordova" ;-)